### PR TITLE
feature/modeus api expansion

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -46,7 +46,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 
 # Clone the repository
 git clone https://github.com/depocoder/YetAnotherCalendar.git
-cd YetAnotherCalendar
+cd YetAnotherCalendar/backend
 
 # Install dependencies
 uv sync
@@ -74,7 +74,7 @@ cp .env.dist .env
 # Edit .env with your configuration
 
 # Start the services
-docker compose up --build -d
+docker-compose up --build -d
 ```
 
 ## 📖 Documentation

--- a/backend/yet_another_calendar/web/api/modeus/schema.py
+++ b/backend/yet_another_calendar/web/api/modeus/schema.py
@@ -1,6 +1,6 @@
 import datetime
 import uuid
-from typing import Self, Annotated
+from typing import Self, Annotated, Any
 
 import jwt
 from fastapi import HTTPException
@@ -56,11 +56,16 @@ class ModeusTimeBody(BaseModel):
         return time_max
 
 
+
+
 # noinspection PyNestedDecorators
 class ModeusEventsBody(ModeusTimeBody):
     """Modeus search events body."""
     size: int = Field(default=50)
     attendee_person_id: list[uuid.UUID] = Field(alias="attendeePersonId")
+
+    # def __init__(self, datetime: datetime.datetime, asd):
+    #     self.datetime_min = datetime.day.
 
     @model_validator(mode='after')
     def check_delta_days(self) -> Self:
@@ -71,6 +76,10 @@ class ModeusEventsBody(ModeusTimeBody):
         if delta.days != 6:
             raise ValueError("Defence between dates must be 7 days.")
         return self
+
+
+class _ModeusEventsBodyWithFilter(ModeusEventsBody):
+    events_filter: dict[str, Any] | None = Field(default=None, alias="eventsFilter")
 
 
 class FullModeusPersonSearch(BaseModel):
@@ -259,5 +268,13 @@ def get_person_id(__jwt: str) -> str:
             detail="Modeus error. Can't decode token", status_code=status.HTTP_400_BAD_REQUEST,
         ) from None
 
+
 def get_cookies_from_headers(modeus_jwt_token: Annotated[str, Header()]) -> str:
     return get_person_id(modeus_jwt_token)
+
+
+class FilteredDayEventsRequest(BaseModel):
+    date: datetime.datetime
+    learning_start_year: list[int] | None = None #Field(examples=["2024"]) # "2024"
+    specialty_code: list[str] | None = None #Field(examples=["09.03.02"]) #"09.03.02"
+    profile_name: list[str] | None = None #Field(examples=["Разработка IT-продуктов и информационных систем"]) #"Разработка IT-продуктов и информационных систем"

--- a/backend/yet_another_calendar/web/api/modeus/views.py
+++ b/backend/yet_another_calendar/web/api/modeus/views.py
@@ -1,7 +1,6 @@
 """
 Modeus API implemented using a controller.
 """
-import datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Header
@@ -28,61 +27,18 @@ async def get_calendar(
     return await integration.get_events(full_body, modeus_jwt_token)
 
 
-# @router.post("/events/by_date/")
-# async def get_calendar_by_date(
-#         body: schema.FilteredDayEventsRequest,
-#         modeus_jwt_token: Annotated[str, Header()],
-#         person_id: Annotated[str, Depends(schema.get_cookies_from_headers)],
-# ) -> list[schema.FullEvent]:
-#     """
-#     Get events from Modeus in a specified day for full group
-#     """
-#     full_body = schema.ModeusEventsBody.model_validate(
-#         {**body.model_dump(by_alias=True), 'attendeePersonId': [person_id]},
-#     )
-#     return await integration.get_events(full_body, modeus_jwt_token)
-
-
-@router.post("/events/by_date/")
-async def get_calendar_by_date(
-        body: schema.FilteredDayEventsRequest,
-        modeus_jwt_token: Annotated[str, Header()],
-        person_id: Annotated[str, Depends(schema.get_cookies_from_headers)],
+@router.post(
+    "/day-events",
+    summary="Расписание группы на выбранный день",
+    response_description="Сырые события Modeus за указанную дату",
+)
+async def day_events(
+    body: schema.DayEventsRequest,
+    modeus_jwt_token: Annotated[str, Header()],
 ) -> list[schema.FullEvent]:
-    """
-    Get events from Modeus in a specified day for full group
-    """
-    local_date: datetime.date = body.date.date()
-    monday = local_date - datetime.timedelta(days=local_date.weekday())
-    sunday = monday + datetime.timedelta(days=6)
-
-    time_min = datetime.datetime.combine(monday,  datetime.time(0, 0), tzinfo=datetime.timezone.utc)
-    time_max = datetime.datetime.combine(sunday, datetime.time(23, 59, 59), tzinfo=datetime.timezone.utc)
-    
-    events_filter: dict[str] = {}
-    if body.specialty_code:
-        events_filter["specialtyCode"] = body.specialty_code
-    if body.learning_start_year:
-        events_filter["learningStartYear"] = body.learning_start_year
-    if body.profile_name:
-        events_filter["profileName"] = body.profile_name
-
-    modeus_body = schema._ModeusEventsBodyWithFilter(
-        timeMin=time_min,
-        timeMax=time_max,
-        attendeePersonId=[person_id],
-        size=500,
-        eventsFilter=events_filter or None,
-    )
-
-    weekly_events = await integration.get_events(modeus_body, modeus_jwt_token)
-
-    day_events = [
-        e for e in weekly_events
-        if e.start_time.astimezone(datetime.timezone.utc).date() == local_date
-    ]
-
-    return day_events
+    """Главный энд-пойнт: возвращает события за день."""
+    events = await integration.get_day_events(modeus_jwt_token, body.to_search_payload())
+    return events
 
 
 @router.post("/auth/")

--- a/backend/yet_another_calendar/web/api/modeus/views.py
+++ b/backend/yet_another_calendar/web/api/modeus/views.py
@@ -1,6 +1,7 @@
 """
 Modeus API implemented using a controller.
 """
+import datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Header
@@ -25,6 +26,63 @@ async def get_calendar(
         {**body.model_dump(by_alias=True), 'attendeePersonId': [person_id]},
     )
     return await integration.get_events(full_body, modeus_jwt_token)
+
+
+# @router.post("/events/by_date/")
+# async def get_calendar_by_date(
+#         body: schema.FilteredDayEventsRequest,
+#         modeus_jwt_token: Annotated[str, Header()],
+#         person_id: Annotated[str, Depends(schema.get_cookies_from_headers)],
+# ) -> list[schema.FullEvent]:
+#     """
+#     Get events from Modeus in a specified day for full group
+#     """
+#     full_body = schema.ModeusEventsBody.model_validate(
+#         {**body.model_dump(by_alias=True), 'attendeePersonId': [person_id]},
+#     )
+#     return await integration.get_events(full_body, modeus_jwt_token)
+
+
+@router.post("/events/by_date/")
+async def get_calendar_by_date(
+        body: schema.FilteredDayEventsRequest,
+        modeus_jwt_token: Annotated[str, Header()],
+        person_id: Annotated[str, Depends(schema.get_cookies_from_headers)],
+) -> list[schema.FullEvent]:
+    """
+    Get events from Modeus in a specified day for full group
+    """
+    local_date: datetime.date = body.date.date()
+    monday = local_date - datetime.timedelta(days=local_date.weekday())
+    sunday = monday + datetime.timedelta(days=6)
+
+    time_min = datetime.datetime.combine(monday,  datetime.time(0, 0), tzinfo=datetime.timezone.utc)
+    time_max = datetime.datetime.combine(sunday, datetime.time(23, 59, 59), tzinfo=datetime.timezone.utc)
+    
+    events_filter: dict[str] = {}
+    if body.specialty_code:
+        events_filter["specialtyCode"] = body.specialty_code
+    if body.learning_start_year:
+        events_filter["learningStartYear"] = body.learning_start_year
+    if body.profile_name:
+        events_filter["profileName"] = body.profile_name
+
+    modeus_body = schema._ModeusEventsBodyWithFilter(
+        timeMin=time_min,
+        timeMax=time_max,
+        attendeePersonId=[person_id],
+        size=500,
+        eventsFilter=events_filter or None,
+    )
+
+    weekly_events = await integration.get_events(modeus_body, modeus_jwt_token)
+
+    day_events = [
+        e for e in weekly_events
+        if e.start_time.astimezone(datetime.timezone.utc).date() == local_date
+    ]
+
+    return day_events
 
 
 @router.post("/auth/")

--- a/backend/yet_another_calendar/web/api/modeus/views.py
+++ b/backend/yet_another_calendar/web/api/modeus/views.py
@@ -28,17 +28,17 @@ async def get_calendar(
 
 
 @router.post(
-    "/day-events",
-    summary="Расписание группы на выбранный день",
-    response_description="Сырые события Modeus за указанную дату",
+    "/day-events/",
+    summary="The group's schedule for the day",
+    response_rescription="Get daily Modeus Events with specific filters"
+    response_model=list[schema.FullEvent],
 )
 async def day_events(
     body: schema.DayEventsRequest,
-    modeus_jwt_token: Annotated[str, Header()],
-) -> list[schema.FullEvent]:
-    """Главный энд-пойнт: возвращает события за день."""
-    events = await integration.get_day_events(modeus_jwt_token, body.to_search_payload())
-    return events
+    modeus_jwt_token: Annotated[str, Header(alias="modeus-jwt-token")],
+):
+    return await integration.get_day_events(modeus_jwt_token, body.to_search_payload())
+
 
 
 @router.post("/auth/")

--- a/backend/yet_another_calendar/web/application.py
+++ b/backend/yet_another_calendar/web/application.py
@@ -65,8 +65,8 @@ def get_app() -> FastAPI:
         title="yet_another_calendar",
         version=metadata.version("yet_another_calendar"),
         lifespan=lifespan_setup,
-        docs_url=None,
-        redoc_url=None,
+        docs_url="/api/docs",
+        redoc_url="/api/redoc",
         openapi_url="/api/openapi.json",
         default_response_class=UJSONResponse,
     )


### PR DESCRIPTION
### Добавил:

- endpoint "/day-events/" 
- func get_day_events
- class DayEventsRequest
- Обновил пустые ссылки в application.py для доступа к Swagger/Redoc
- Поправил синтаксис для backend/readme.md

#### Feature description:
Явная передача номера группы в API Modeus не обнаружена
Группа определяется по трём признакам: году поступления, номеру и названию специальности (learningStartYear, specialtyCode и profileName соответственно).
#### Пример заполнения:
```
{
  "date": "2025-05-20",
  "learningStartYear": [
    2024
  ],
  "profileName": [
    "Разработка IT-продуктов и информационных систем"
  ],
  "specialtyCode": [
    "09.03.02"
  ]
}
```

В ответ получаем response, сериализируем и получаем знакомый modeus event. 

**Коммиты направлены напрямую без верификации, т.к. есть проблемы с прогоном в локальном окружении. **


В будущем есть вариант создать hardcode справочник для групп, которым потребуется сохранение ссылок на MTS Link, с присвоением реального номера группы