### PR TITLE
Add support for subdomain-based login flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ YetAnotherCalendar provides a unified interface to manage all your educational e
 docker compose -f docker-compose.prod.yaml up -d
 ```
 
+### 🔁 Local subdomain setup for development
+
+To enable subdomain-based login flows in development (e.g. separate autofill for Netology and Modeus login forms), you need to add a custom host entry:
+
+1. Open your `hosts` file:
+   - **Windows**: `C:\Windows\System32\drivers\etc\hosts`
+   - **macOS / Linux**: `/etc/hosts`
+
+2. Add the following line:
+
 ## 🤝 Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -46,8 +46,17 @@ services:
     restart: always
     volumes:
       - ./frontend/src:/app/src
+    expose:
+      - "3000"
+        
+  frontend-proxy:
+    image: nginx:1.23
     ports:
-      - "3000:3000"
+      - "3000:80"
+    volumes:
+      - ./frontend/nginx-dev.conf:/etc/nginx/conf.d/default.conf
+    depends_on:
+      - frontend
 
 volumes:
   redis_data:

--- a/frontend/nginx-dev.conf
+++ b/frontend/nginx-dev.conf
@@ -1,0 +1,27 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    location / {
+        proxy_pass http://frontend:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+    }
+}
+
+server {
+    listen 80;
+    server_name modeus.localhost;
+
+    location / {
+        proxy_pass http://frontend:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+    }
+}

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,12 +1,23 @@
 server {
+    listen 80;
+    server_name localhost yetanothercalendar.ru;
 
-  listen 80;
-  server_name localhost;
+    root /usr/share/nginx/html/;
+    index index.html;
 
-  root /usr/share/nginx/html/;
-  index index.html;
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}
 
-  location / {
-    try_files $uri $uri/ /index.html;
-  }
+server {
+    listen 80;
+    server_name modeus.localhost modeus.yetanothercalendar.ru;
+
+    root /usr/share/nginx/html/;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
 }

--- a/frontend/src/components/login/login.jsx
+++ b/frontend/src/components/login/login.jsx
@@ -19,8 +19,8 @@ const Login = ({ onLogin, title, name, formId }) => {
 
     return (
         <div className="login-netologiya">
-            <div class="loginLogo-container">
-                <center><img src={`/${formId}.png`} alt={`Лого ${name}`} class="loginLogo"/></center>
+            <div className="loginLogo-container">
+                <center><img src={`/${formId}.png`} alt={`Лого ${name}`} className="loginLogo"/></center>
             </div>
             <label>{title}</label>
             <div style={{ display: "flex", flexDirection: "column" }}>
@@ -45,7 +45,7 @@ const Login = ({ onLogin, title, name, formId }) => {
                     id={`password-${formId}`}
                     name={`password-${formId}`}
                     placeholder={`Пароль от ${name}`}
-                    utoComplete={`${formId}-current-password`}
+                    autoComplete={`${formId}-current-password`}
                     onChange={(e) => setPassword(e.target.value)}
                     required
                 />


### PR DESCRIPTION
Shity-shit, fuck it all

npm start не поддерживает modeus.localhost:3000 по умолчанию
→ сделано проксирование через nginx при сборке dev версии
→ добавлен nginx-dev, исправлен docker-compose
→ добавлен пункт Readme, что нужно добавлять modeus.localhost в /etc/hosts на каждой машине разработчика

На чем я сдулся:
Передача токенов между поддоменами ломается в истории с двумя доменами
→ localStorage не общий, поэтому после логина Нетологии редирект на логин модеуса на отдельном поддомене ведет к крашу флоу логина